### PR TITLE
Redesign LoadingSkeleton with shimmer overlay and structured placeholders

### DIFF
--- a/components/LoadingSkeleton.tsx
+++ b/components/LoadingSkeleton.tsx
@@ -1,26 +1,58 @@
 import { motion } from 'motion/react';
 
+const skeletonBlock =
+  'relative overflow-hidden rounded-md border border-gray-200/80 bg-gray-100/80 dark:border-neutral-800 dark:bg-neutral-900';
+
+function Shimmer() {
+  return (
+    <motion.span
+      aria-hidden
+      className="absolute inset-y-0 -left-1/2 w-1/2 bg-gradient-to-r from-transparent via-white/70 to-transparent dark:via-white/10"
+      animate={{ x: ['0%', '300%'] }}
+      transition={{ duration: 1.4, repeat: Infinity, ease: 'linear' }}
+    />
+  );
+}
+
 export default function LoadingSkeleton() {
   return (
     <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2, ease: 'easeOut' }}
       className="w-full"
     >
-      <div className="max-w-4xl mx-auto space-y-4">
-        {/* Header Skeleton */}
-        <div className="h-8 bg-gray-200 rounded-lg w-1/3 animate-pulse"></div>
-        
-        {/* Content Skeletons */}
-        <div className="space-y-3">
+      <div className="mx-auto max-w-4xl space-y-5">
+        <div className={`${skeletonBlock} h-12 w-2/5`}>
+          <Shimmer />
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-3">
           {[...Array(3)].map((_, i) => (
-            <div key={i} className="space-y-2">
-              <div className="h-4 bg-gray-200 rounded-sm w-3/4 animate-pulse"></div>
-              <div className="h-4 bg-gray-200 rounded-sm animate-pulse"></div>
-              <div className="h-4 bg-gray-200 rounded-sm w-5/6 animate-pulse"></div>
+            <div key={i} className={`${skeletonBlock} h-20`}>
+              <Shimmer />
             </div>
           ))}
         </div>
+
+        {[...Array(3)].map((_, i) => (
+          <article key={i} className="rounded-lg border border-gray-200/80 bg-white/80 p-4 dark:border-neutral-800 dark:bg-neutral-950/80">
+            <div className="space-y-3">
+              <div className={`${skeletonBlock} h-5 w-1/3`}>
+                <Shimmer />
+              </div>
+              <div className={`${skeletonBlock} h-4 w-full`}>
+                <Shimmer />
+              </div>
+              <div className={`${skeletonBlock} h-4 w-5/6`}>
+                <Shimmer />
+              </div>
+              <div className={`${skeletonBlock} h-4 w-2/3`}>
+                <Shimmer />
+              </div>
+            </div>
+          </article>
+        ))}
       </div>
     </motion.div>
   );


### PR DESCRIPTION
### Motivation
- Improve perceived loading UX by replacing simple pulse blocks with a richer, structured skeleton that better mirrors real page layout.
- Provide a consistent visual treatment and dark-mode support for all placeholder elements using a shared style token.
- Smooth the entrance of the loading state with a subtle upward easing animation for less jarring route transitions.

### Description
- Updated `components/LoadingSkeleton.tsx` to introduce a reusable `skeletonBlock` class string for consistent styling and dark-mode variants across placeholders.
- Added a `Shimmer` subcomponent implemented with `motion.span` that animates a gradient overlay to create a shimmer effect on every placeholder.
- Reworked layout into a staged structure: a title/header block, a 3-card stat row, and repeated content/article rows composed of the new skeleton blocks.
- Adjusted the container animation to `initial={{ opacity: 0, y: 8 }}` and `animate={{ opacity: 1, y: 0 }}` with a short `transition` for smoother entrance.

### Testing
- Ran `npm run lint`, which failed due to an existing ESLint configuration/rule error involving `@next/next/no-html-link-for-pages` on `pages/404.tsx` (unrelated to this change).
- Ran `npm run build`, which failed during the project's lint/type checks for the same ESLint issue and an unrelated TypeScript error in `components/expense/ViewToggle.tsx` (also unrelated to this change).
- No component-level unit tests were present or run in this change set; visual verification expected after resolving the existing project lint/type issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cabfabc04c832e99b8df8f7042939b)